### PR TITLE
fix: sync closed issues by switching State filter to all

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,37 @@
+# Auto-detect text files and normalise line endings to LF.
+* text=auto eol=lf
+# Go sources
+*.go text eol=lf diff=golang
+# SQL
+*.sql text eol=lf
+# Config / data
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+# Documentation
+*.md text eol=lf
+*.txt text eol=lf
+# Scripts
+*.sh text eol=lf
+# Go module files
+go.mod text eol=lf
+go.sum text eol=lf
+# CI / tooling
+Taskfile.yaml text eol=lf
+Dockerfile text eol=lf
+.gitignore text eol=lf
+.gitattributes text eol=lf
+.golangci.yml text eol=lf
+.sqlfluff text eol=lf
+.licenserc.yaml text eol=lf
+LICENSE text eol=lf
+# Binaries — no diff, no merge, no text conversion
+*.db binary
+*.sqlite binary
+*.exe binary
+*.wasm binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary

--- a/internal/infrastructure/github/client.go
+++ b/internal/infrastructure/github/client.go
@@ -43,7 +43,7 @@ func NewClient(client *github.Client, logger *slog.Logger) *Client {
 	return &Client{client: client, logger: logger}
 }
 
-// GetMostUpdatedIssues fetches open issues from the given repository,
+// GetMostUpdatedIssues fetches issues from the given repository,
 // sorted by update time (oldest first).
 //
 // The client is stateless per repository — owner and repo are explicit parameters.
@@ -70,7 +70,7 @@ func (p *Client) GetMostUpdatedIssues(ctx context.Context, owner, repo string, c
 	}
 
 	opts := &github.IssueListByRepoOptions{
-		State:     "open",
+		State:     "all",
 		Sort:      "updated",
 		Direction: "asc",
 		Since:     since,


### PR DESCRIPTION
## Summary
Closed issues were never synced because `GetMostUpdatedIssues` hardcoded `State: "open"`.
Changed to `State: "all"` so both open and closed issues are fetched.
> Previously closed issues that were not updated after the cursor position will require a manual cursor reset (resync) — tracked separately.
Closes #94
Closes #74
## Changes
- `internal/infrastructure/github/client.go`: `State: "open"` → `State: "all"`
- Updated godoc comment to reflect the change
- Added `.gitattributes` with LF normalisation, Go diff driver, and binary rules