### PR TITLE
fix: flush telemetry when InitializeKernel fails (#100)

### DIFF
--- a/internal/bootstrap/kernel.go
+++ b/internal/bootstrap/kernel.go
@@ -19,35 +19,29 @@ import (
 	"database/sql"
 	"io"
 	"log/slog"
-	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/thumbrise/autosolve/cmd"
-	"github.com/thumbrise/autosolve/internal/infrastructure/telemetry"
 )
 
 const envPrefix = "AUTOSOLVE"
-
-type ShutdownFunc func(ctx context.Context) error
 
 type Kernel struct {
 	rootCommand *cmd.Root
 	commands    []*cobra.Command
 	db          *sql.DB
-	telemetry   *telemetry.Telemetry
 	logger      *slog.Logger
 }
 
-func NewKernel(commands []*cobra.Command, logger *slog.Logger, rootCommand *cmd.Root, db *sql.DB, telemetry *telemetry.Telemetry) *Kernel {
-	return &Kernel{commands: commands, logger: logger, rootCommand: rootCommand, db: db, telemetry: telemetry}
+func NewKernel(commands []*cobra.Command, db *sql.DB, logger *slog.Logger, rootCommand *cmd.Root) *Kernel {
+	return &Kernel{commands: commands, db: db, logger: logger, rootCommand: rootCommand}
 }
 
 func (b *Kernel) Execute(ctx context.Context, output io.Writer) error {
 	b.registerCommands()
-	b.rootCommand.SetOut(output)
 
-	defer b.shutdown(ctx, 5*time.Second, b.telemetry.Shutdown)
+	b.rootCommand.SetOut(output)
 	defer b.shutdownDB(ctx)
 
 	return b.rootCommand.ExecuteContext(ctx)
@@ -62,17 +56,5 @@ func (b *Kernel) registerCommands() {
 func (b *Kernel) shutdownDB(ctx context.Context) {
 	if err := b.db.Close(); err != nil {
 		b.logger.ErrorContext(ctx, "failed to close database", slog.Any("error", err))
-	}
-}
-
-func (b *Kernel) shutdown(ctx context.Context, timeout time.Duration, fn ShutdownFunc) {
-	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
-	defer cancel()
-
-	err := fn(shutdownCtx)
-	if err != nil {
-		b.logger.ErrorContext(shutdownCtx, "shutdown error",
-			slog.Any("error", err),
-		)
 	}
 }

--- a/internal/bootstrap/wire.go
+++ b/internal/bootstrap/wire.go
@@ -26,7 +26,6 @@ import (
 	"github.com/thumbrise/autosolve/internal"
 	"github.com/thumbrise/autosolve/internal/config"
 	configinfra "github.com/thumbrise/autosolve/internal/infrastructure/config"
-	"github.com/thumbrise/autosolve/internal/infrastructure/telemetry"
 )
 
 func InitializeKernel(
@@ -34,7 +33,6 @@ func InitializeKernel(
 	_ *configinfra.Reader,
 	_ *config.Log,
 	_ *slog.Logger,
-	_ *telemetry.Telemetry,
 ) (*Kernel, error) {
 	wire.Build(
 		NewKernel,

--- a/internal/bootstrap/wire_gen.go
+++ b/internal/bootstrap/wire_gen.go
@@ -19,13 +19,12 @@ import (
 	"github.com/thumbrise/autosolve/internal/infrastructure/dal/sqlcgen"
 	"github.com/thumbrise/autosolve/internal/infrastructure/database"
 	"github.com/thumbrise/autosolve/internal/infrastructure/github"
-	"github.com/thumbrise/autosolve/internal/infrastructure/telemetry"
 	"log/slog"
 )
 
 // Injectors from wire.go:
 
-func InitializeKernel(contextContext context.Context, reader *config.Reader, log *config2.Log, logger *slog.Logger, telemetryTelemetry *telemetry.Telemetry) (*Kernel, error) {
+func InitializeKernel(contextContext context.Context, reader *config.Reader, log *config2.Log, logger *slog.Logger) (*Kernel, error) {
 	configGithub, err := config2.NewGithub(contextContext, reader)
 	if err != nil {
 		return nil, err
@@ -66,6 +65,6 @@ func InitializeKernel(contextContext context.Context, reader *config.Reader, log
 	testSubTree := cmds.NewTestSubTree(logger)
 	v3 := cmd.NewCommands(schedule, migrate, migrateUp, migrateUpFresh, migrateDown, migrateStatus, migrateCreate, migrateRedo, test, testSubTree)
 	root := cmd.NewRoot()
-	kernel := NewKernel(v3, logger, root, db, telemetryTelemetry)
+	kernel := NewKernel(v3, db, logger, root)
 	return kernel, nil
 }

--- a/internal/infrastructure/telemetry/telemetry.go
+++ b/internal/infrastructure/telemetry/telemetry.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/log/global"
@@ -56,6 +58,8 @@ type Telemetry struct {
 	meterProvider  *sdkmetric.MeterProvider
 	loggerProvider *sdklog.LoggerProvider
 	logger         *slog.Logger
+	shutdownOnce   sync.Once
+	shutdownErr    error
 }
 
 const none = "none"
@@ -121,6 +125,17 @@ func New(ctx context.Context, cfg *config.Otel, logger *slog.Logger) (*Telemetry
 // Shutdown flushes and releases all OTEL SDK resources.
 // Shutdown order is reverse of creation: logs → metrics → traces.
 func (t *Telemetry) Shutdown(ctx context.Context) error {
+	t.shutdownOnce.Do(func() {
+		t.shutdownErr = t.doShutdown(ctx)
+	})
+
+	return t.shutdownErr
+}
+
+func (t *Telemetry) doShutdown(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+
 	var errs error
 
 	if t.loggerProvider != nil {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,57 +19,66 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/thumbrise/autosolve/internal/bootstrap"
+	"github.com/thumbrise/autosolve/internal/infrastructure/telemetry"
 )
 
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	exitCode := 0
 
-	if err := run(ctx); err != nil {
-		log.Println(err)
-
-		exitCode = 1
-	}
+	code := run(ctx)
 
 	cancel()
-	os.Exit(exitCode)
+	os.Exit(code)
 }
 
-func run(ctx context.Context) error {
+func run(ctx context.Context) int {
 	boot, err := bootstrap.Bootstrap(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to bootstrap: %w", err)
+		log.Printf("failed to bootstrap: %s", err)
+
+		return 1
 	}
+	defer func(Telemetry *telemetry.Telemetry, ctx context.Context) {
+		_ = Telemetry.Shutdown(ctx)
+	}(boot.Telemetry, ctx)
 
 	kernel, err := bootstrap.InitializeKernel(
 		ctx,
 		boot.ConfigReader,
 		boot.ConfigLog,
 		boot.Logger,
-		boot.Telemetry,
 	)
 	if err != nil {
-		return fmt.Errorf("failed initialize kernel: %w", err)
+		return handleError(ctx, boot, fmt.Errorf("failed initialize kernel: %w", err))
 	}
 
 	var output bytes.Buffer
 
 	err = kernel.Execute(ctx, &output)
+	flushOutput(&output)
 
-	// Flush buffered command output after all shutdown hooks completed.
-	// This guarantees logs and command output never interleave.
+	if err != nil {
+		return handleError(ctx, boot, fmt.Errorf("execution failed: %w", err))
+	}
+
+	return 0
+}
+
+func handleError(ctx context.Context, boot *bootstrap.Boot, err error) int {
+	boot.Logger.ErrorContext(ctx, "fatal error", slog.Any("error", err))
+	log.Println(err)
+
+	return 1
+}
+
+func flushOutput(output *bytes.Buffer) {
 	if output.Len() > 0 {
 		fmt.Print(output.String())
 	}
-
-	if err != nil {
-		return fmt.Errorf("execution failed: %w", err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
## Summary
Telemetry was not flushed when `InitializeKernel` failed — all accumulated spans, metrics and logs were silently lost.
## Root Cause
`Telemetry.Shutdown` was only called inside `Kernel.Execute()` via defer. If `InitializeKernel` returned an error before `Execute` was reached, shutdown never happened.
## Changes
### `main.go`
- `Bootstrap` moved to `main()`, result passed into `run()`
- `run()` returns exit code instead of error
- `defer boot.Telemetry.Shutdown(ctx)` guarantees flush on any exit path
- `handleError()` logs fatal errors to both OTEL and stderr
- `flushOutput()` extracted for clarity
### `internal/infrastructure/telemetry/telemetry.go`
- `Shutdown` made idempotent via `sync.Once` — safe to call from both `run()` defer and `Kernel.Execute()`
- `doShutdown` uses `context.WithoutCancel` + 5s timeout to survive signal cancellation
### `internal/bootstrap/kernel.go`
- Removed `telemetry` field and `shutdown()` method — Kernel no longer owns telemetry lifecycle
- Removed `ShutdownFunc` type
### `internal/bootstrap/wire.go` / `wire_gen.go`
- Removed `*telemetry.Telemetry` parameter from `InitializeKernel`
Closes #100