### PR TITLE
Refactor commands, telemetry lifecycle, and output buffering

### DIFF
--- a/cmd/cmds/migrate.go
+++ b/cmd/cmds/migrate.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -33,14 +34,6 @@ var (
 )
 
 // Migrate is a proxy command that dispatches goose operations.
-//
-// It hides inconvenient parameters (directory, dialect, DSN) so the developer
-// can simply run:
-//
-//	go run . migrate status
-//	go run . migrate up
-//	go run . migrate down 1
-//	go run . migrate create add_users
 type Migrate struct {
 	*cobra.Command
 }
@@ -54,39 +47,23 @@ func NewMigrate() *Migrate {
 	return &Migrate{root}
 }
 
-type MigrateUp struct {
-	*cobra.Command
-}
+type (
+	MigrateUp      struct{ *cobra.Command }
+	MigrateUpFresh struct{ *cobra.Command }
+	MigrateDown    struct{ *cobra.Command }
+	MigrateStatus  struct{ *cobra.Command }
+	MigrateCreate  struct{ *cobra.Command }
+	MigrateRedo    struct{ *cobra.Command }
+)
 
-type MigrateUpFresh struct {
-	*cobra.Command
-}
-
-type MigrateDown struct {
-	*cobra.Command
-}
-
-type MigrateStatus struct {
-	*cobra.Command
-}
-
-type MigrateCreate struct {
-	*cobra.Command
-}
-
-type MigrateRedo struct {
-	*cobra.Command
-}
-
-func NewMigrateUp(migrator *database.Migrator) *MigrateUp {
+func NewMigrateUp(migrator *database.Migrator, logger *slog.Logger) *MigrateUp {
 	cmd := &cobra.Command{
 		Use:   "up [steps]",
 		Short: "Apply pending migrations (all by default)",
 		Long:  "Apply pending migrations. Optionally pass step count.\nRequires --yes or interactive confirmation.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			yes, _ := cmd.Flags().GetBool("yes")
-			if !yes && !confirmInteractive(cmd, "Apply pending migrations?") {
+			if !confirmed(cmd, "Apply pending migrations?") {
 				cmd.Println("aborted")
 
 				return nil
@@ -98,11 +75,11 @@ func NewMigrateUp(migrator *database.Migrator) *MigrateUp {
 			}
 
 			results, err := migrator.Up(cmd.Context(), steps)
+			printResults(cmd, logger, results)
+
 			if err != nil {
 				return err
 			}
-
-			printApplied(cmd, results)
 
 			if len(results) == 0 {
 				cmd.Println("no pending migrations")
@@ -111,66 +88,59 @@ func NewMigrateUp(migrator *database.Migrator) *MigrateUp {
 			return nil
 		},
 	}
-
 	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 
 	return &MigrateUp{cmd}
 }
 
-func NewMigrateUpFresh(migrator *database.Migrator) *MigrateUpFresh {
+func NewMigrateUpFresh(migrator *database.Migrator, logger *slog.Logger) *MigrateUpFresh {
 	cmd := &cobra.Command{
 		Use:   "up:fresh",
 		Short: "Drop all tables and re-run all migrations",
 		Long:  "Rolls back all migrations, then applies all from scratch.\nRequires --yes or interactive confirmation.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			yes, _ := cmd.Flags().GetBool("yes")
-			if !yes && !confirmInteractive(cmd, "Drop ALL tables and re-run ALL migrations?") {
+			if !confirmed(cmd, "Drop ALL tables and re-run ALL migrations?") {
 				cmd.Println("aborted")
 
 				return nil
 			}
 
-			results, err := migrator.Fresh(cmd.Context())
+			downResults, upResults, err := migrator.Fresh(cmd.Context())
+			printResults(cmd, logger, downResults)
+			printResults(cmd, logger, upResults)
+
 			if err != nil {
 				return err
 			}
 
-			printApplied(cmd, results)
 			cmd.Println("fresh migration complete")
 
 			return nil
 		},
 	}
-
 	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 
 	return &MigrateUpFresh{cmd}
 }
 
-func NewMigrateDown(migrator *database.Migrator) *MigrateDown {
+func NewMigrateDown(migrator *database.Migrator, logger *slog.Logger) *MigrateDown {
 	cmd := &cobra.Command{
 		Use:   "down <steps|*>",
 		Short: "Roll back migrations",
 		Long:  "Roll back migrations. Requires step count or * for all.\nRequires --yes or interactive confirmation.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			yes, _ := cmd.Flags().GetBool("yes")
-
 			if args[0] == "*" {
-				if !yes && !confirmInteractive(cmd, "Roll back ALL migrations?") {
+				if !confirmed(cmd, "Roll back ALL migrations?") {
 					cmd.Println("aborted")
 
 					return nil
 				}
 
 				results, err := migrator.DownAll(cmd.Context())
-				if err != nil {
-					return err
-				}
+				printResults(cmd, logger, results)
 
-				printRolledBack(cmd, results)
-
-				return nil
+				return err
 			}
 
 			steps, err := strconv.Atoi(args[0])
@@ -178,23 +148,18 @@ func NewMigrateDown(migrator *database.Migrator) *MigrateDown {
 				return fmt.Errorf("%w: got %q", ErrInvalidDownArgs, args[0])
 			}
 
-			if !yes && !confirmInteractive(cmd, fmt.Sprintf("Roll back %d migration(s)?", steps)) {
+			if !confirmed(cmd, fmt.Sprintf("Roll back %d migration(s)?", steps)) {
 				cmd.Println("aborted")
 
 				return nil
 			}
 
 			results, err := migrator.Down(cmd.Context(), steps)
-			if err != nil {
-				return err
-			}
+			printResults(cmd, logger, results)
 
-			printRolledBack(cmd, results)
-
-			return nil
+			return err
 		},
 	}
-
 	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 
 	return &MigrateDown{cmd}
@@ -238,38 +203,37 @@ func NewMigrateCreate(migrator *database.Migrator) *MigrateCreate {
 	}}
 }
 
-func NewMigrateRedo(migrator *database.Migrator) *MigrateRedo {
+func NewMigrateRedo(migrator *database.Migrator, logger *slog.Logger) *MigrateRedo {
 	cmd := &cobra.Command{
 		Use:   "redo",
 		Short: "Roll back the last migration, then re-apply it",
 		Long:  "Equivalent to down 1 + up 1.\nRequires --yes or interactive confirmation.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			yes, _ := cmd.Flags().GetBool("yes")
-			if !yes && !confirmInteractive(cmd, "Redo the last migration?") {
+			if !confirmed(cmd, "Redo the last migration?") {
 				cmd.Println("aborted")
 
 				return nil
 			}
 
 			downResults, upResults, err := migrator.Redo(cmd.Context())
-			if err != nil {
-				return err
-			}
+			printResults(cmd, logger, downResults)
+			printResults(cmd, logger, upResults)
 
-			printRolledBack(cmd, downResults)
-			printApplied(cmd, upResults)
-
-			return nil
+			return err
 		},
 	}
-
 	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 
 	return &MigrateRedo{cmd}
 }
 
-// confirmInteractive prints a prompt and waits for y/n from stdin.
-func confirmInteractive(cmd *cobra.Command, prompt string) bool {
+// confirmed checks --yes flag or prompts interactively.
+func confirmed(cmd *cobra.Command, prompt string) bool {
+	yes, _ := cmd.Flags().GetBool("yes")
+	if yes {
+		return true
+	}
+
 	cmd.PrintErr(prompt + " [y/N] ")
 
 	scanner := bufio.NewScanner(cmd.InOrStdin())
@@ -293,14 +257,16 @@ func parseSteps(args []string) (int, error) {
 	return steps, nil
 }
 
-func printApplied(cmd *cobra.Command, results []*goose.MigrationResult) {
+// printResults prints migration results to CLI output and emits structured log
+// entries so migration operations are observable via the telemetry pipeline.
+// Safe to call with nil or empty slice.
+func printResults(cmd *cobra.Command, logger *slog.Logger, results []*goose.MigrationResult) {
 	for _, r := range results {
-		cmd.Printf("APPLIED      %s (%s)\n", r.Source.Path, r.Duration)
-	}
-}
-
-func printRolledBack(cmd *cobra.Command, results []*goose.MigrationResult) {
-	for _, r := range results {
-		cmd.Printf("ROLLED BACK  %s (%s)\n", r.Source.Path, r.Duration)
+		cmd.Println(r.String())
+		logger.InfoContext(cmd.Context(), "migration executed",
+			slog.String("direction", r.Direction),
+			slog.String("file", r.Source.Path),
+			slog.String("duration", r.Duration.String()),
+		)
 	}
 }

--- a/internal/bootstrap/wire_gen.go
+++ b/internal/bootstrap/wire_gen.go
@@ -51,16 +51,16 @@ func InitializeKernel(contextContext context.Context, reader *config.Reader, log
 	scheduler := application.NewScheduler(planner, logger)
 	schedule := cmds.NewSchedule(scheduler)
 	migrate := cmds.NewMigrate()
-	migrator, err := database.NewMigrator(db, logger)
+	migrator, err := database.NewMigrator(db)
 	if err != nil {
 		return nil, err
 	}
-	migrateUp := cmds.NewMigrateUp(migrator)
-	migrateUpFresh := cmds.NewMigrateUpFresh(migrator)
-	migrateDown := cmds.NewMigrateDown(migrator)
+	migrateUp := cmds.NewMigrateUp(migrator, logger)
+	migrateUpFresh := cmds.NewMigrateUpFresh(migrator, logger)
+	migrateDown := cmds.NewMigrateDown(migrator, logger)
 	migrateStatus := cmds.NewMigrateStatus(migrator)
 	migrateCreate := cmds.NewMigrateCreate(migrator)
-	migrateRedo := cmds.NewMigrateRedo(migrator)
+	migrateRedo := cmds.NewMigrateRedo(migrator, logger)
 	test := cmds.NewTest(logger)
 	testSubTree := cmds.NewTestSubTree(logger)
 	v3 := cmd.NewCommands(schedule, migrate, migrateUp, migrateUpFresh, migrateDown, migrateStatus, migrateCreate, migrateRedo, test, testSubTree)

--- a/internal/infrastructure/database/migrator.go
+++ b/internal/infrastructure/database/migrator.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -44,12 +43,17 @@ var ErrMigrationFailed = errors.New("migration failed")
 // Runtime operations (Up, Down, Status, Redo) use the embedded migration files
 // compiled into the binary. Create writes new files to disk and is intended
 // for development only.
+//
+// Methods that apply migrations return []*goose.MigrationResult and error.
+// On partial failure goose returns a *goose.PartialError containing both
+// the successfully applied migrations and the failed one.
+// Migrator preserves this contract — callers can use errors.As to extract
+// partial results when needed.
 type Migrator struct {
 	provider *goose.Provider
-	logger   *slog.Logger
 }
 
-func NewMigrator(db *sql.DB, logger *slog.Logger) (*Migrator, error) {
+func NewMigrator(db *sql.DB) (*Migrator, error) {
 	migrations, err := fs.Sub(embeddedMigrations, "migrations")
 	if err != nil {
 		return nil, fmt.Errorf("%w: sub fs: %w", ErrMigrationFailed, err)
@@ -60,25 +64,24 @@ func NewMigrator(db *sql.DB, logger *slog.Logger) (*Migrator, error) {
 		return nil, fmt.Errorf("%w: create provider: %w", ErrMigrationFailed, err)
 	}
 
-	return &Migrator{provider: provider, logger: logger}, nil
+	return &Migrator{provider: provider}, nil
 }
 
 // Up applies pending migrations. If steps <= 0, applies all pending migrations.
 // Otherwise applies exactly that many steps.
+//
+// On partial failure the error wraps *goose.PartialError with applied results.
 func (m *Migrator) Up(ctx context.Context, steps int) ([]*goose.MigrationResult, error) {
 	if steps <= 0 {
 		results, err := m.provider.Up(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("%w: up: %w", ErrMigrationFailed, err)
+			return results, fmt.Errorf("%w: up: %w", ErrMigrationFailed, err)
 		}
-
-		m.logApplied(ctx, results)
 
 		return results, nil
 	}
 
 	results := make([]*goose.MigrationResult, 0, steps)
-
 	for range steps {
 		r, err := m.provider.UpByOne(ctx)
 		if err != nil {
@@ -92,15 +95,12 @@ func (m *Migrator) Up(ctx context.Context, steps int) ([]*goose.MigrationResult,
 		results = append(results, r)
 	}
 
-	m.logApplied(ctx, results)
-
 	return results, nil
 }
 
 // Down rolls back applied migrations. Steps must be > 0, or use DownAll.
 func (m *Migrator) Down(ctx context.Context, steps int) ([]*goose.MigrationResult, error) {
 	results := make([]*goose.MigrationResult, 0, steps)
-
 	for range steps {
 		r, err := m.provider.Down(ctx)
 		if err != nil {
@@ -114,8 +114,6 @@ func (m *Migrator) Down(ctx context.Context, steps int) ([]*goose.MigrationResul
 		results = append(results, r)
 	}
 
-	m.logRolledBack(ctx, results)
-
 	return results, nil
 }
 
@@ -123,10 +121,8 @@ func (m *Migrator) Down(ctx context.Context, steps int) ([]*goose.MigrationResul
 func (m *Migrator) DownAll(ctx context.Context) ([]*goose.MigrationResult, error) {
 	results, err := m.provider.DownTo(ctx, 0)
 	if err != nil {
-		return nil, fmt.Errorf("%w: down all: %w", ErrMigrationFailed, err)
+		return results, fmt.Errorf("%w: down all: %w", ErrMigrationFailed, err)
 	}
-
-	m.logRolledBack(ctx, results)
 
 	return results, nil
 }
@@ -145,12 +141,12 @@ func (m *Migrator) Status(ctx context.Context) ([]*goose.MigrationStatus, error)
 func (m *Migrator) Redo(ctx context.Context) ([]*goose.MigrationResult, []*goose.MigrationResult, error) {
 	downResults, err := m.Down(ctx, 1)
 	if err != nil {
-		return nil, nil, err
+		return downResults, nil, err
 	}
 
 	upResults, err := m.Up(ctx, 1)
 	if err != nil {
-		return downResults, nil, err
+		return downResults, upResults, err
 	}
 
 	return downResults, upResults, nil
@@ -158,35 +154,23 @@ func (m *Migrator) Redo(ctx context.Context) ([]*goose.MigrationResult, []*goose
 
 // Fresh drops all tables and re-applies all migrations from scratch.
 // Development-only operation — equivalent to Laravel's migrate:fresh.
-func (m *Migrator) Fresh(ctx context.Context) ([]*goose.MigrationResult, error) {
-	if _, err := m.DownAll(ctx); err != nil {
-		return nil, err
+//
+// Returns both down and up results so the caller can observe the full operation.
+// On DownAll failure only downResults are populated. On Up failure both slices
+// contain whatever was completed before the error.
+func (m *Migrator) Fresh(ctx context.Context) ([]*goose.MigrationResult, []*goose.MigrationResult, error) {
+	downResults, err := m.DownAll(ctx)
+	if err != nil {
+		return downResults, nil, err
 	}
 
-	return m.Up(ctx, 0)
-}
+	upResults, err := m.Up(ctx, 0)
 
-func (m *Migrator) logApplied(ctx context.Context, results []*goose.MigrationResult) {
-	for _, r := range results {
-		m.logger.InfoContext(ctx, "migration applied",
-			slog.String("file", r.Source.Path),
-			slog.String("duration", r.Duration.String()),
-		)
-	}
-}
-
-func (m *Migrator) logRolledBack(ctx context.Context, results []*goose.MigrationResult) {
-	for _, r := range results {
-		m.logger.InfoContext(ctx, "migration rolled back",
-			slog.String("file", r.Source.Path),
-			slog.String("duration", r.Duration.String()),
-		)
-	}
+	return downResults, upResults, err
 }
 
 var sqlMigrationTemplate = template.Must(template.New("goose.sql-migration").Parse(
 	`-- +goose Up
-
 -- +goose Down
 `))
 

--- a/main.go
+++ b/main.go
@@ -31,13 +31,21 @@ import (
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 
-	code := run(ctx)
+	var output bytes.Buffer
+
+	code := run(ctx, &output)
 
 	cancel()
+
+	if output.Len() > 0 {
+		fmt.Printf("\noutput:\n")
+		fmt.Print(output.String())
+	}
+
 	os.Exit(code)
 }
 
-func run(ctx context.Context) int {
+func run(ctx context.Context, output *bytes.Buffer) int {
 	boot, err := bootstrap.Bootstrap(ctx)
 	if err != nil {
 		log.Printf("failed to bootstrap: %s", err)
@@ -58,11 +66,7 @@ func run(ctx context.Context) int {
 		return handleError(ctx, boot, fmt.Errorf("failed initialize kernel: %w", err))
 	}
 
-	var output bytes.Buffer
-
-	err = kernel.Execute(ctx, &output)
-	flushOutput(&output)
-
+	err = kernel.Execute(ctx, output)
 	if err != nil {
 		return handleError(ctx, boot, fmt.Errorf("execution failed: %w", err))
 	}
@@ -75,10 +79,4 @@ func handleError(ctx context.Context, boot *bootstrap.Boot, err error) int {
 	log.Println(err)
 
 	return 1
-}
-
-func flushOutput(output *bytes.Buffer) {
-	if output.Len() > 0 {
-		fmt.Print(output.String())
-	}
 }


### PR DESCRIPTION
## Changes
### Fix: preserve partial migration results on error (#84)
- `Migrator.Up()`, `DownAll()`, `Redo()` now return collected results alongside the error instead of discarding them with `nil`
- Removed `logApplied`/`logRolledBack` from Migrator — CLI layer owns presentation
### Refactor: consolidate CLI helpers
- Unified `--yes` flag check into `confirmed()` helper (was duplicated at every call site)  
- Replaced `printApplied`/`printRolledBack` with single `printResults` using `goose.MigrationResult.String()`
- Simplified error handling: `printResults` called unconditionally before `return err`
### Refactor: hoist output buffer to main()
- `bytes.Buffer` moved from `run()` to `main()` so output is flushed even on non-zero exit
- Removed `flushOutput` helper
Closes #84
