### PR TITLE
fix: stabilize outbox — N-fold dedup, optional Ollama config, HTTP timeout (#154)

### DIFF
--- a/cmd/cmds/dev.go
+++ b/cmd/cmds/dev.go
@@ -136,7 +136,7 @@ type issueEvent struct {
 func (s *devServer) handleEvents(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	events, err := s.queries.PendingOutboxEvents(ctx, s.db, sqlcgen.PendingOutboxEventsParams{
+	events, err := s.queries.PendingOutboxEventsAll(ctx, s.db, sqlcgen.PendingOutboxEventsAllParams{
 		Topic: "issues:synced",
 		Limit: 100,
 	})
@@ -172,7 +172,7 @@ func (s *devServer) handleEvents(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		s.processOutboxEvent(ctx, w, flusher, ev, prompt)
+		s.processOutboxEvent(ctx, w, flusher, sqlcgen.PendingOutboxEventsRow(ev), prompt)
 	}
 
 	_, _ = fmt.Fprintf(w, "data: {\"type\":\"complete\"}\n\n")

--- a/internal/config/ollama.go
+++ b/internal/config/ollama.go
@@ -21,8 +21,8 @@ import (
 )
 
 type Ollama struct {
-	Endpoint string `validate:"required"`
-	Model    string `validate:"required"`
+	Endpoint string
+	Model    string
 }
 
 func NewOllama(ctx context.Context, reader *config.Reader) (*Ollama, error) {

--- a/internal/domain/spec/workers/issue_explainer.go
+++ b/internal/domain/spec/workers/issue_explainer.go
@@ -51,10 +51,11 @@ func (ie *IssueExplainer) TaskSpec() spec.WorkerSpec {
 	}
 }
 
-func (ie *IssueExplainer) Run(ctx context.Context, _ tenants.RepositoryTenant) error {
+func (ie *IssueExplainer) Run(ctx context.Context, tenant tenants.RepositoryTenant) error {
 	events, err := ie.queries.PendingOutboxEvents(ctx, ie.db, sqlcgen.PendingOutboxEventsParams{
-		Topic: outboxTopicIssuesSynced,
-		Limit: outboxBatchLimit,
+		Topic:        outboxTopicIssuesSynced,
+		RepositoryID: tenant.RepositoryID,
+		Limit:        outboxBatchLimit,
 	})
 	if err != nil {
 		return fmt.Errorf("read outbox: %w", err)

--- a/internal/infrastructure/dal/queries/outbox.sql
+++ b/internal/infrastructure/dal/queries/outbox.sql
@@ -5,6 +5,13 @@ VALUES (?, ?, ?);
 -- name: PendingOutboxEvents :many
 SELECT id, created_at, topic, resource_id, repository_id
 FROM outbox_events
+WHERE topic = ? AND repository_id = ? AND processed_at IS NULL
+ORDER BY created_at ASC
+LIMIT ?;
+
+-- name: PendingOutboxEventsAll :many
+SELECT id, created_at, topic, resource_id, repository_id
+FROM outbox_events
 WHERE topic = ? AND processed_at IS NULL
 ORDER BY created_at ASC
 LIMIT ?;

--- a/internal/infrastructure/dal/sqlcgen/issues.sql.go
+++ b/internal/infrastructure/dal/sqlcgen/issues.sql.go
@@ -67,6 +67,13 @@ type GetLastUpdateTimeRow struct {
 	GithubUpdatedAt time.Time
 }
 
+func (q *Queries) GetLastUpdateTime(ctx context.Context, db DBTX, repositoryID int64) (GetLastUpdateTimeRow, error) {
+	row := db.QueryRowContext(ctx, getLastUpdateTime, repositoryID)
+	var i GetLastUpdateTimeRow
+	err := row.Scan(&i.GithubID, &i.GithubUpdatedAt)
+	return i, err
+}
+
 const listIssues = `-- name: ListIssues :many
 SELECT id, repository_id, number, title, state
 FROM issues
@@ -90,7 +97,13 @@ func (q *Queries) ListIssues(ctx context.Context, db DBTX) ([]ListIssuesRow, err
 	items := []ListIssuesRow{}
 	for rows.Next() {
 		var i ListIssuesRow
-		if err := rows.Scan(&i.ID, &i.RepositoryID, &i.Number, &i.Title, &i.State); err != nil {
+		if err := rows.Scan(
+			&i.ID,
+			&i.RepositoryID,
+			&i.Number,
+			&i.Title,
+			&i.State,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -102,13 +115,6 @@ func (q *Queries) ListIssues(ctx context.Context, db DBTX) ([]ListIssuesRow, err
 		return nil, err
 	}
 	return items, nil
-}
-
-func (q *Queries) GetLastUpdateTime(ctx context.Context, db DBTX, repositoryID int64) (GetLastUpdateTimeRow, error) {
-	row := db.QueryRowContext(ctx, getLastUpdateTime, repositoryID)
-	var i GetLastUpdateTimeRow
-	err := row.Scan(&i.GithubID, &i.GithubUpdatedAt)
-	return i, err
 }
 
 const upsertIssue = `-- name: UpsertIssue :exec

--- a/internal/infrastructure/dal/sqlcgen/outbox.sql.go
+++ b/internal/infrastructure/dal/sqlcgen/outbox.sql.go
@@ -54,14 +54,15 @@ func (q *Queries) InsertOutboxEvent(ctx context.Context, db DBTX, arg InsertOutb
 const pendingOutboxEvents = `-- name: PendingOutboxEvents :many
 SELECT id, created_at, topic, resource_id, repository_id
 FROM outbox_events
-WHERE topic = ? AND processed_at IS NULL
+WHERE topic = ? AND repository_id = ? AND processed_at IS NULL
 ORDER BY created_at ASC
 LIMIT ?
 `
 
 type PendingOutboxEventsParams struct {
-	Topic string
-	Limit int64
+	Topic        string
+	RepositoryID int64
+	Limit        int64
 }
 
 type PendingOutboxEventsRow struct {
@@ -73,7 +74,7 @@ type PendingOutboxEventsRow struct {
 }
 
 func (q *Queries) PendingOutboxEvents(ctx context.Context, db DBTX, arg PendingOutboxEventsParams) ([]PendingOutboxEventsRow, error) {
-	rows, err := db.QueryContext(ctx, pendingOutboxEvents, arg.Topic, arg.Limit)
+	rows, err := db.QueryContext(ctx, pendingOutboxEvents, arg.Topic, arg.RepositoryID, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
@@ -81,6 +82,56 @@ func (q *Queries) PendingOutboxEvents(ctx context.Context, db DBTX, arg PendingO
 	items := []PendingOutboxEventsRow{}
 	for rows.Next() {
 		var i PendingOutboxEventsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.CreatedAt,
+			&i.Topic,
+			&i.ResourceID,
+			&i.RepositoryID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const pendingOutboxEventsAll = `-- name: PendingOutboxEventsAll :many
+SELECT id, created_at, topic, resource_id, repository_id
+FROM outbox_events
+WHERE topic = ? AND processed_at IS NULL
+ORDER BY created_at ASC
+LIMIT ?
+`
+
+type PendingOutboxEventsAllParams struct {
+	Topic string
+	Limit int64
+}
+
+type PendingOutboxEventsAllRow struct {
+	ID           int64
+	CreatedAt    time.Time
+	Topic        string
+	ResourceID   int64
+	RepositoryID int64
+}
+
+func (q *Queries) PendingOutboxEventsAll(ctx context.Context, db DBTX, arg PendingOutboxEventsAllParams) ([]PendingOutboxEventsAllRow, error) {
+	rows, err := db.QueryContext(ctx, pendingOutboxEventsAll, arg.Topic, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []PendingOutboxEventsAllRow{}
+	for rows.Next() {
+		var i PendingOutboxEventsAllRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.CreatedAt,

--- a/internal/infrastructure/ollama/client.go
+++ b/internal/infrastructure/ollama/client.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/thumbrise/autosolve/internal/config"
 )
@@ -35,8 +36,16 @@ type Client struct {
 	httpClient *http.Client
 }
 
+// DefaultTimeout is the default HTTP timeout for Ollama requests.
+const DefaultTimeout = 2 * time.Minute
+
 func NewClient(cfg *config.Ollama) *Client {
-	return &Client{cfg: cfg, httpClient: &http.Client{}}
+	return &Client{
+		cfg: cfg,
+		httpClient: &http.Client{
+			Timeout: DefaultTimeout,
+		},
+	}
 }
 
 type generateRequest struct {


### PR DESCRIPTION
- PendingOutboxEvents filters by repository_id (fixes N-fold duplicate processing)
- PendingOutboxEventsAll for dev dashboard (repo-agnostic)
- Ollama config fields no longer required (unblocks migrate/schedule without ollama section)
- Ollama HTTP client gets 2min default timeout (prevents hung workers)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thumbrise/autosolve/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
