### PR TITLE
fix: goqite schema comment, idempotent comment posting, outbox relay (#166, #177, #162)

### DIFF
--- a/cmd/cmds/jobs_show.go
+++ b/cmd/cmds/jobs_show.go
@@ -69,6 +69,7 @@ func NewJobsShow(db *sql.DB) *JobsShow {
 			} else {
 				pretty = body
 			}
+
 			if err != nil {
 				return fmt.Errorf("json marshal: %w", err)
 			}

--- a/internal/domain/spec/workers/issue_explainer.go
+++ b/internal/domain/spec/workers/issue_explainer.go
@@ -288,6 +288,23 @@ func (e *IssueExplainer) analyzeAndPost(ctx context.Context, repo sqlcgen.GetRep
 
 	commentBody := formatComment(e.ollama.Model(), response)
 
+	// Guard against duplicate comments on message redelivery (#177).
+	// If the process crashed after posting but before queue.Delete,
+	// the marker will already be present — skip posting.
+	alreadyPosted, err := e.github.HasCommentWithMarker(ctx, repo.Owner, repo.Name, int(issue.Number), autosolveMarker)
+	if err != nil {
+		return fmt.Errorf("idempotency check for issue %d: %w", job.IssueID, err)
+	}
+
+	if alreadyPosted {
+		e.logger.WarnContext(ctx, "duplicate suppressed, comment already exists",
+			slog.Int64("issueId", job.IssueID),
+			slog.Int64("issueNumber", issue.Number),
+		)
+
+		return nil
+	}
+
 	if err := e.github.CreateIssueComment(ctx, repo.Owner, repo.Name, int(issue.Number), commentBody); err != nil {
 		return fmt.Errorf("post comment for issue %d: %w", job.IssueID, err)
 	}

--- a/internal/domain/spec/workers/outbox_relay.go
+++ b/internal/domain/spec/workers/outbox_relay.go
@@ -209,6 +209,11 @@ func (r *OutboxRelay) relayEvent(ctx context.Context, ev sqlcgen.PendingOutboxEv
 		slog.String("issueTitle", issue.Title),
 	)
 
+	// Send and Ack are not wrapped in a transaction because the DB pool has
+	// MaxOpenConns=1 and goqite.Send uses the same *sql.DB internally.
+	// BeginTx would hold the only connection, causing goqite.Send to deadlock.
+	// The idempotency guard in analyzeAndPost (#177) handles the rare case
+	// where Send succeeds but Ack fails on crash — duplicate jobs are harmless.
 	if err := r.queue.Send(ctx, jobType, ev.RepositoryID, issue.ID); err != nil {
 		return fmt.Errorf("enqueue job for issue #%d: %w", ev.ResourceID, err)
 	}

--- a/internal/infrastructure/database/migrations/004_create_jobs.sql
+++ b/internal/infrastructure/database/migrations/004_create_jobs.sql
@@ -1,4 +1,6 @@
 -- +goose Up
+-- Schema corresponds to goqite v0.4.0 (maragu.dev/goqite).
+-- If upgrading goqite, check whether the expected table schema has changed.
 
 CREATE TABLE IF NOT EXISTS goqite
 (


### PR DESCRIPTION
## Summary
Fix three issues targeting v0.1 — Dispatch MVP milestone.
### #166 — Migration 004: add goqite schema version comment
Added version-tracking SQL comment to `004_create_jobs.sql` documenting goqite v0.4.0 schema.
### #177 — Idempotent GitHub comment posting
Added `HasCommentWithMarker` guard inside `analyzeAndPost` before `CreateIssueComment`. If the process crashed after posting but before `queue.Delete`, the marker is already present on redelivery — duplicate suppressed.
### #162 — OutboxRelay: prevent duplicate jobs
Investigated wrapping `Send`+`Ack` in a transaction, but `MaxOpenConns=1` + goqite using the same `*sql.DB` causes deadlock. Reverted to sequential auto-commit with an explanatory comment. The idempotency guard from #177 already covers the rare Send-ok-Ack-fail crash scenario.
Closes #166
Closes #177
Closes #162